### PR TITLE
Specify ordering in the output JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Reference dataset: ./data/track_categories.yaml
 
 2. Build the database:
 
-- `$ docker-compose run web python manage.py make migrations`
+- `$ docker-compose run web python manage.py makemigrations`
 - `$ docker-compose run web python manage.py migrate`
 - `$ docker-compose run web python ./utils/import_data.py`
 

--- a/tracks/models.py
+++ b/tracks/models.py
@@ -18,6 +18,9 @@ class Category(models.Model):
     label = models.CharField(max_length=100)
     track_category_id = models.CharField(max_length=100, blank=True, default="")
 
+    class Meta:
+        ordering = ['id']
+
 
 class CategoryType(models.Model):
     category = models.ManyToManyField(Category, related_name="types")
@@ -37,3 +40,6 @@ class Track(models.Model):
     label = models.CharField(max_length=100)
     track_id = models.CharField(max_length=100)
     additional_info = models.TextField(blank=True, default="")
+
+    class Meta:
+        ordering = ['id']


### PR DESCRIPTION
This PR will explicitly set the ordering of the categories and tracks arrays in the database (and in the output JSON) to match the source datafile.

JIRA ticket : [ENSWBSITES-1312](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1312)
