### PR TITLE
Removed redundant data sections

### DIFF
--- a/data/track_categories.yaml
+++ b/data/track_categories.yaml
@@ -58,20 +58,6 @@ genome_track_categories:
       types:
         - 'Variation'
 
-    - label: 'Experiment design'
-      track_category_id: 'experiment-design'
-      track_list: []
-      types:
-        - 'Genomic'
-        - 'Expression'
-        - 'Variation'
-
-    - label: 'References & evidence'
-      track_category_id: 'references-evidence'
-      track_list: []
-      types:
-        - 'Genomic'
-
     - label: 'Regulatory features'
       track_category_id: 'regulatory-features'
       track_list: []
@@ -148,20 +134,6 @@ genome_track_categories:
       types:
         - 'Variation'
 
-    - label: 'Experiment design'
-      track_category_id: 'experiment-design'
-      track_list: []
-      types:
-        - 'Genomic'
-        - 'Expression'
-        - 'Variation'
-
-    - label: 'References & evidence'
-      track_category_id: 'references-evidence'
-      track_list: []
-      types:
-        - 'Genomic'
-
     - label: 'Regulatory features'
       track_category_id: 'regulatory-features'
       track_list: []
@@ -235,20 +207,6 @@ genome_track_categories:
       track_list: []
       types:
         - 'Variation'
-
-    - label: 'Experiment design'
-      track_category_id: 'experiment-design'
-      track_list: []
-      types:
-        - 'Genomic'
-        - 'Expression'
-        - 'Variation'
-
-    - label: 'References & evidence'
-      track_category_id: 'references-evidence'
-      track_list: []
-      types:
-        - 'Genomic'
 
     - label: 'Regulatory features'
       track_category_id: 'regulatory-features'
@@ -324,20 +282,6 @@ genome_track_categories:
       types:
         - 'Variation'
 
-    - label: 'Experiment design'
-      track_category_id: 'experiment-design'
-      track_list: []
-      types:
-        - 'Genomic'
-        - 'Expression'
-        - 'Variation'
-
-    - label: 'References & evidence'
-      track_category_id: 'references-evidence'
-      track_list: []
-      types:
-        - 'Genomic'
-
     - label: 'Regulatory features'
       track_category_id: 'regulatory-features'
       track_list: []
@@ -411,20 +355,6 @@ genome_track_categories:
       track_list: []
       types:
         - 'Variation'
-
-    - label: 'Experiment design'
-      track_category_id: 'experiment-design'
-      track_list: []
-      types:
-        - 'Genomic'
-        - 'Expression'
-        - 'Variation'
-
-    - label: 'References & evidence'
-      track_category_id: 'references-evidence'
-      track_list: []
-      types:
-        - 'Genomic'
 
     - label: 'Regulatory features'
       track_category_id: 'regulatory-features'
@@ -500,20 +430,6 @@ genome_track_categories:
       types:
         - 'Variation'
 
-    - label: 'Experiment design'
-      track_category_id: 'experiment-design'
-      track_list: []
-      types:
-        - 'Genomic'
-        - 'Expression'
-        - 'Variation'
-
-    - label: 'References & evidence'
-      track_category_id: 'references-evidence'
-      track_list: []
-      types:
-        - 'Genomic'
-
     - label: 'Regulatory features'
       track_category_id: 'regulatory-features'
       track_list: []
@@ -587,20 +503,6 @@ genome_track_categories:
       track_list: []
       types:
         - 'Variation'
-
-    - label: 'Experiment design'
-      track_category_id: 'experiment-design'
-      track_list: []
-      types:
-        - 'Genomic'
-        - 'Expression'
-        - 'Variation'
-
-    - label: 'References & evidence'
-      track_category_id: 'references-evidence'
-      track_list: []
-      types:
-        - 'Genomic'
 
     - label: 'Regulatory features'
       track_category_id: 'regulatory-features'


### PR DESCRIPTION
Removed "Experiment Design" and "References & Evidence" data sections from the source data file.
The data changes will be applied to the database with `utils/import_data.py` script.

Related JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1354