### PR TITLE
Refactor genomeid to use new 

### DIFF
--- a/data/track_categories.yaml
+++ b/data/track_categories.yaml
@@ -299,7 +299,7 @@ genome_track_categories:
       track_list: []
       types:
         - 'Expression'
-  escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2:
+  escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2:
     - label: 'Genes & transcripts'
       track_category_id: 'genes-transcripts'
       track_list:
@@ -521,8 +521,7 @@ genome_track_categories:
       track_list: []
       types:
         - 'Expression'
-
-  3704ceb1-948d-11ec-a39d-005056b38ce3:
+  a7335667-93e7-11ec-a39d-005056b38ce3:
     - label: 'Genes & transcripts'
       track_category_id: 'genes-transcripts'
       track_list:
@@ -748,7 +747,7 @@ genome_track_categories:
       track_list: []
       types:
         - 'Expression'
-  a733574a-93e7-11ec-a39d-005056b38ce3_2:
+  a733574a-93e7-11ec-a39d-005056b38ce3:
     - label: 'Genes & transcripts'
       track_category_id: 'genes-transcripts'
       track_list:


### PR DESCRIPTION
Adds New genome uuids for the 7 species.

Deployment URL : 
http://2020.ensembl.org/
http://refactor-genomeid.review.ensembl.org/

Examples:
e.coli : http://2020.ensembl.org/api/tracks/track_categories/a733574a-93e7-11ec-a39d-005056b38ce3

JIRA : 
https://www.ebi.ac.uk/panda/jira/browse/EWB-43

Once entire stack gets migrated to us new genome_uuids, 

-  Old genome_ids should be removed from track_categories.yaml and it should only contain new genome_uuids. 
-  Remove old genome_ids from the database as well.

Note : Can be merge to main as the changes are only in the data which doesn't have any side effect.


