### PR TITLE
Update tracks, migrate dev to main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,32 +1,19 @@
 stages:
     - build
-    - deploy
+    - deploy-preview
+    - deploy-prod
 
 variables:
-    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
+    DOCKER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
     DOCKER_TLS_CERTDIR: ""
 
 .branch-rules-main:
     rules:
         - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
           when: on_success
-        - when: never
-
-.branch-rules-dev:
-    rules:
-        - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "dev"'
-          when: on_success
-        - when: never
-
-.build-rules:
-    rules:
-        - if: '$CI_DEPLOY_FREEZE == null'
-          when: on_success
-        - when: never
 
 #Base templates
 .deploy:
-    stage: deploy
     image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
     before_script:
         - kubectl config use-context ${AGENT}
@@ -34,7 +21,7 @@ variables:
     script:
         - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
         - cd ensembl-k8s-manifests/ensembl-web-track-api
-        - kustomize edit set image DOCKER_IMAGE=${CONTAINER_IMAGE}
+        - kustomize edit set image DOCKER_IMAGE=${DOCKER_IMAGE}
         - kubectl apply -k .
 
 .deploy-main:
@@ -42,14 +29,8 @@ variables:
         - .deploy
         - .branch-rules-main
 
-.deploy-dev:
-    extends:
-        - .deploy
-        - .branch-rules-dev
-
 #Build docker image 
 Docker:
-    extends: .build-rules
     stage: build
     image: docker
     services:
@@ -57,29 +38,34 @@ Docker:
     before_script:
         - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
     script:
-        - docker build -t ${CONTAINER_IMAGE} --no-cache -f Dockerfile .
-        - docker push ${CONTAINER_IMAGE}
-        - docker rmi ${CONTAINER_IMAGE}
+        - docker build -t ${DOCKER_IMAGE} --no-cache -f Dockerfile .
+        - docker push ${DOCKER_IMAGE}
+        - docker rmi ${DOCKER_IMAGE}
         - docker logout $CI_REGISTRY
 
 #Deploy to k8s
 Prod:
+  stage: deploy-prod
   extends: .deploy-main
   environment:
     name: production
+  when: manual
   variables:
     AGENT: ${PROD_AGENT}
     NS: ${PROD_NS}
 
 Fallback:
+  stage: deploy-prod
   extends: .deploy-main
   environment:
     name: fallback
+  when: manual
   variables:
     AGENT: ${FALLBACK_AGENT}
     NS: ${FALLBACK_NS}
 
 Staging:
+  stage: deploy-preview
   extends: .deploy-dev
   environment:
     name: staging
@@ -88,6 +74,7 @@ Staging:
     NS: ${STAGING_NS}
 
 Internal:
+  stage: deploy-preview
   extends: .deploy-dev
   environment:
     name: internal
@@ -96,6 +83,7 @@ Internal:
     NS: ${INTERNAL_NS}
 
 Dev:
+  stage: deploy-preview
   extends: .deploy-dev
   environment:
     name: development

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 stages:
     - build
-    - deploy-preview
+    - deploy-test
     - deploy-prod
 
 variables:
@@ -35,7 +35,7 @@ variables:
         - .deploy
         - .branch-rules-main
 
-.deploy-all:
+.deploy-review:
     extends:
         - .deploy
         - .branch-rules-review
@@ -76,7 +76,7 @@ Fallback:
     NS: ${FALLBACK_NS}
 
 Staging:
-  stage: deploy-preview
+  stage: deploy-test
   extends: .deploy-main
   environment:
     name: staging
@@ -84,18 +84,9 @@ Staging:
     AGENT: ${STAGING_AGENT}
     NS: ${STAGING_NS}
 
-Internal:
-  stage: deploy-preview
-  extends: .deploy-all
-  environment:
-    name: internal
-  variables:
-    AGENT: ${INTERNAL_AGENT}
-    NS: ${INTERNAL_NS}
-
 Dev:
-  stage: deploy-preview
-  extends: .deploy-all
+  stage: deploy-test
+  extends: .deploy-review
   environment:
     name: development
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,13 +9,13 @@ variables:
 
 .branch-rules-main:
     rules:
-        - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
+        - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"
           when: on_success
 
 .branch-rules-review:
     extends: .branch-rules-main
     rules:
-        - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH != "main"'
+        - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH != "main"
           when: manual
 
 #Base templates

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
     extends: .branch-rules-main
     rules:
         - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH != "main"
-          when: manual
+          when: on_success
 
 #Base templates
 .deploy:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,8 +9,14 @@ variables:
 
 .branch-rules-main:
     rules:
-        - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
+        - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
           when: on_success
+
+.branch-rules-review:
+    extends: .branch-rules-main
+    rules:
+        - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH != "main"'
+          when: manual
 
 #Base templates
 .deploy:
@@ -28,6 +34,11 @@ variables:
     extends:
         - .deploy
         - .branch-rules-main
+
+.deploy-all:
+    extends:
+        - .deploy
+        - .branch-rules-review
 
 #Build docker image 
 Docker:
@@ -66,7 +77,7 @@ Fallback:
 
 Staging:
   stage: deploy-preview
-  extends: .deploy-dev
+  extends: .deploy-main
   environment:
     name: staging
   variables:
@@ -75,7 +86,7 @@ Staging:
 
 Internal:
   stage: deploy-preview
-  extends: .deploy-dev
+  extends: .deploy-all
   environment:
     name: internal
   variables:
@@ -84,7 +95,7 @@ Internal:
 
 Dev:
   stage: deploy-preview
-  extends: .deploy-dev
+  extends: .deploy-all
   environment:
     name: development
   variables:

--- a/templates/gc.yaml
+++ b/templates/gc.yaml
@@ -8,7 +8,7 @@ trigger:
   - gc
 type: regular
 label: "%GC"
-display_order: 900
+display_order: 200
 on_by_default: false
 description: Shows the percentage of Gs and Cs in a region
 datafiles:

--- a/templates/gene-track-desc.csv
+++ b/templates/gene-track-desc.csv
@@ -2288,7 +2288,6 @@ channa_maculata_gca020496755v1,9b0cadf5-7a7d-43f3-b1de-3b25191720f3,channa_macul
 montipora_capitata_gca949126865v1,2016214e-4b9a-4f3b-8d75-1b6ea20232eb,montipora_capitata_gca949126865v1_core_110_1,Ensembl,https://rapid.ensembl.org/info/genome/genebuild/anno.html,Annotated
 cranoglanis_bouderius_gca023630585v1,8dc538c2-7b39-42ee-a7b4-817a185aabd3,cranoglanis_bouderius_gca023630585v1_core_110_1,Ensembl,https://rapid.ensembl.org/info/genome/genebuild/full_genebuild.html,Annotated
 oryzias_curvinotus_gca023969325v1,bd6a478c-a8b9-487e-8c7e-0fa880965bcd,oryzias_curvinotus_gca023969325v1_core_110_1,Ensembl,https://rapid.ensembl.org/info/genome/genebuild/full_genebuild.html,Annotated
-erysiphe_necator_gca_000798715,763330b7-4678-4f50-8457-993212eb3b46,fungi_ascomycota2_collection_core_57_110_1,University of California, Davis,http://www.ebi.ac.uk/ena/browser/view/GCA_000798715,Imported
 culex_quinquefasciatus_gcf015732765v1vb,69f24be6-9e3d-4de5-9da3-33f40c018482,culex_quinquefasciatus_gcf015732765v1vb_core_110_1,VectorBase,https://vectorbase.org/vectorbase/app/record/dataset/TMPTX_cquiJHB,Imported
 gasterosteus_nipponicus_gca014132575v2,19885986-6b80-4105-8200-532aa8cc2cfc,gasterosteus_nipponicus_gca014132575v2_core_110_1,Ensembl,https://rapid.ensembl.org/info/genome/genebuild/full_genebuild.html,Annotated
 albula_goreensis_gca022829145v1,b7c1accd-7265-4211-a182-58ac44abed5b,albula_goreensis_gca022829145v1_core_110_1,Ensembl,https://rapid.ensembl.org/info/genome/genebuild/full_genebuild.html,Annotated

--- a/templates/gerp-elements.yaml
+++ b/templates/gerp-elements.yaml
@@ -8,7 +8,7 @@ trigger:
   - expand
 type: regular
 label: Constrained elements
-display_order: 960
+display_order: 401
 on_by_default: false
 description: |-
   Displays constrained elements, which are stretches of genomic sequences that are highly conserved according to the conservation score. 

--- a/templates/gerp-scores.yaml
+++ b/templates/gerp-scores.yaml
@@ -8,7 +8,7 @@ trigger:
   - expand
 type: regular
 label: Conservation scores
-display_order: 950
+display_order: 400
 on_by_default: false
 description: |-
   Displays per-basepair conservation scores, indicating how many species in a given multiple alignment match at each locus. 

--- a/templates/regulatory-features.yaml
+++ b/templates/regulatory-features.yaml
@@ -8,7 +8,7 @@ trigger:
   - regulation
 type: regular
 label: Regulatory annotation
-display_order: 890
+display_order: 300
 on_by_default: true
 description: |-
   Promoters, enhancers and open chromatin regions are available for all species. 

--- a/templates/repeat-elements.yaml
+++ b/templates/repeat-elements.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: Repeat elements
-display_order: 985
+display_order: 600
 on_by_default: false
 description: Shows repeat regions on the genome
 datafiles:

--- a/templates/repeats.centromere_repeat.yaml
+++ b/templates/repeats.centromere_repeat.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Repeats: Centromere"
-display_order: 985
+display_order: 640
 on_by_default: false
 description: Centromere genomic locations defined by the Genome Reference Consortium
 sources:

--- a/templates/repeats.dust.yaml
+++ b/templates/repeats.dust.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Low complexity: Dust"
-display_order: 984
+display_order: 620
 on_by_default: false
 description: Shows low complexity regions (regions of the genome with a biased distribution of nucleotides, such as a repeat) on the genome, identified by Dust
 sources:

--- a/templates/repeats.ena_repeat.yaml
+++ b/templates/repeats.ena_repeat.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Repeats: ENA"
-display_order: 980
+display_order: 650
 on_by_default: true
 description: Shows repeat regions annotated in ENA
 sources:

--- a/templates/repeats.long_terminal_repeat.yaml
+++ b/templates/repeats.long_terminal_repeat.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Repeats: Pombase LTR"
-display_order: 988
+display_order: 630
 on_by_default: false
 description: LTR simple features annotated by PomBase and imported into Ensembl
 sources:

--- a/templates/repeats.low_complexity_region.yaml
+++ b/templates/repeats.low_complexity_region.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Low complexity: Pombase"
-display_order: 986
+display_order: 621
 on_by_default: false
 description: Low complexity region simple features annotated by PomBase and imported into Ensembl
 sources:

--- a/templates/repeats.ltr_retrotransposon.yaml
+++ b/templates/repeats.ltr_retrotransposon.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Repeats: Pombase LTR retrotransposon"
-display_order: 987
+display_order: 631
 on_by_default: false
 description: LTR retrotransponson simple features annotated by PomBase and imported into Ensembl
 sources:

--- a/templates/repeats.repeatdetector.yaml
+++ b/templates/repeats.repeatdetector.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Repeats: RED"
-display_order: 980
+display_order: 670
 on_by_default: false
 description: Shows repeat regions on the genome, identified by RED (REpeatDetector)
 sources:

--- a/templates/repeats.repeatdetector_annotated.yaml
+++ b/templates/repeats.repeatdetector_annotated.yaml
@@ -14,7 +14,7 @@ settings:
 type: regular
 label: "Repeats: RED"
 additional_info: Annotated
-display_order: 981
+display_order: 671
 on_by_default: false
 description: Shows repeat regions on the genome, identified by RED (REpeatDetector) and annotated by alignment to a repeat library
 sources:

--- a/templates/repeats.repeatmask.yaml
+++ b/templates/repeats.repeatmask.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Repeats: Repeatmasker"
-display_order: 980
+display_order: 610
 on_by_default: false
 description: Shows repeat regions on the genome, identified by RepeatMasker using a RepBase, or custom generated repeat library
 sources:

--- a/templates/repeats.repeatmask_customlib.yaml
+++ b/templates/repeats.repeatmask_customlib.yaml
@@ -14,7 +14,7 @@ settings:
 type: regular
 label: "Repeats: Repeatmasker"
 additional_info: Custom library
-display_order: 982
+display_order: 614
 on_by_default: false
 description: Repeats identified by RepeatMasker, using a custom library of <em>ab initio</em> repeat profiles for this species
 sources:

--- a/templates/repeats.repeatmask_nrplants.yaml
+++ b/templates/repeats.repeatmask_nrplants.yaml
@@ -14,7 +14,7 @@ settings:
 type: regular
 label: "Repeats: RepeatMasker"
 additional_info: nrplants
-display_order: 982
+display_order: 615
 on_by_default: false
 description: Shows repeats detected using RepeatMasker to scan non-redundant elements from several plant libraries, including REdat, TREP and RepetDB among others
 sources:

--- a/templates/repeats.repeatmask_redat.yaml
+++ b/templates/repeats.repeatmask_redat.yaml
@@ -14,7 +14,7 @@ settings:
 type: regular
 label: "Repeats: RepeatMasker"
 additional_info: REdat
-display_order: 983
+display_order: 616
 on_by_default: false
 description: Shows repeats detected using RepeatMasker with MIPS Repeat Database (REdat) 
 sources:

--- a/templates/repeats.repeatmask_repbase.yaml
+++ b/templates/repeats.repeatmask_repbase.yaml
@@ -14,7 +14,7 @@ settings:
 type: regular
 label: "Repeats: Repeatmasker"
 additional_info: RepBase
-display_order: 981
+display_order: 611
 on_by_default: false
 description: Shows repeat regions on the genome, identified by RepeatMasker using a RepBase repeat library
 sources:

--- a/templates/repeats.repeatmask_repbase_human.yaml
+++ b/templates/repeats.repeatmask_repbase_human.yaml
@@ -14,7 +14,7 @@ settings:
 type: regular
 label: "Repeats: Repeatmasker"
 additional_info: RepBase human
-display_order: 981
+display_order: 612
 on_by_default: false
 description: Shows repeat regions on the genome, identified by RepeatMasker using a RepBase repeat library
 sources:

--- a/templates/repeats.repeatmask_repbase_human_low.yaml
+++ b/templates/repeats.repeatmask_repbase_human_low.yaml
@@ -14,7 +14,7 @@ settings:
 type: regular
 label: "Repeats: Repeatmasker"
 additional_info: RepBase human low complexity
-display_order: 982
+display_order: 613
 on_by_default: false
 description: Shows repeat regions on the genome, identified by RepeatMasker using a RepBase repeat library
 sources:

--- a/templates/repeats.repeatmaskagi.yaml
+++ b/templates/repeats.repeatmaskagi.yaml
@@ -14,7 +14,7 @@ settings:
 type: regular
 label: "Repeats: Repeatmasker"
 additional_info: AGI library
-display_order: 981
+display_order: 617
 on_by_default: false
 description: Shows repeat regions on the genome, identified by RepeatMasker using the AGI library
 sources:

--- a/templates/repeats.trf.yaml
+++ b/templates/repeats.trf.yaml
@@ -13,7 +13,7 @@ settings:
     scales: [9, 100, 4]
 type: regular
 label: "Repeats: TRF"
-display_order: 983
+display_order: 660
 on_by_default: false
 description: Shows repeat regions on the genome, identified by Tandem Repeats Finder
 sources:

--- a/templates/simple-features-cpg.yaml
+++ b/templates/simple-features-cpg.yaml
@@ -8,7 +8,7 @@ trigger:
   - expand
 type: regular
 label: CpG islands
-display_order: 971
+display_order: 501
 on_by_default: false
 description: |-
   Displays CpG islands - regions of nucleic acid sequence containing a high number of adjacent cytosine-guanine pairs (along one strand). 

--- a/templates/simple-features-tssp.yaml
+++ b/templates/simple-features-tssp.yaml
@@ -8,7 +8,7 @@ trigger:
   - expand
 type: regular
 label: Transcription start sites
-display_order: 970
+display_order: 500
 on_by_default: false
 description: Displays transcription start sites predicted by Eponine-TSS
 sources:

--- a/utils/README.md
+++ b/utils/README.md
@@ -8,12 +8,27 @@ or by pointing it to a data directory (by setting `TRACK_API_DIR` environment va
 to Track API by matching each datafile (with `.bb`, `.bw` extension) with corresponding template file: a template filename must match or start with the datafile name to be submitted.
 The datafile parent directory names are used to fill in the genome UUID field (override via `--genome` param).
 
-Examples:
+Example:
 ```bash
 export TRACK_API_URL=http://localhost:8000 # target track API
 export TRACK_DATA_DIR=/Users/Alice/datafiles # track datafiles
-
+./utils/submit_track_templates.py #submit tracks for all datafiles in data dir
 ```
+For more detailed instructions for production, refer to [ENSWEBSOPS-171](https://www.ebi.ac.uk/panda/jira/browse/ENSWEBSOPS-171).
+
+
+#### Notes
+Data submission script combines input from multiple sources:
+| Source | Where | Why |
+|-------|-------|------|
+| Templates | `/tempaltes/*.yaml` | Track payload base |
+| Overrides | `/tempaltes/*.csv` | Species-specific values |
+| Datafiles | Input data dir | Specify species/tracks to submit |
+
+The datafiles source can be replaced/modified with command-line params (`-g`,`-t`).
 
 ### Legacy scripts
-
+Scripts kept for historical record, safe to be be removed.
+- import_data.py: legacy data importer script; useful as an example of updating tracks database through Django datamodels 
+- grant_access.sh: useful when read/write database users don't have a shared db schema
+- submit_tracks_241: initial track submission script

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,19 @@
+## Utility scripts
+
+### Bulk data updater
+
+`submit_track_templates.py` script constructs and submits track payloads to Track API `POST` endpoint to add new tracks.
+It uses the yaml templates in `/templates` to fill the payload fields. You specify the submitted track types (templates) with  `--template` parameter, 
+or by pointing it to a data directory (by setting `TRACK_API_DIR` environment variable). In the latter case the script tries to sync the data directory
+to Track API by matching each datafile (with `.bb`, `.bw` extension) with corresponding template file: a template filename must match or start with the datafile name to be submitted.
+The datafile parent directory names are used to fill in the genome UUID field (override via `--genome` param).
+
+Examples:
+```bash
+export TRACK_API_URL=http://localhost:8000 # target track API
+export TRACK_DATA_DIR=/Users/Alice/datafiles # track datafiles
+
+```
+
+### Legacy scripts
+

--- a/utils/README.md
+++ b/utils/README.md
@@ -17,7 +17,7 @@ export TRACK_DATA_DIR=/Users/Alice/datafiles # track datafiles
 For more detailed instructions for production, refer to [ENSWEBSOPS-171](https://www.ebi.ac.uk/panda/jira/browse/ENSWEBSOPS-171).
 
 
-#### Notes
+#### Data sources
 Data submission script combines input from multiple sources:
 | Source | Where | Why |
 |-------|-------|------|
@@ -25,10 +25,11 @@ Data submission script combines input from multiple sources:
 | Overrides | `/tempaltes/*.csv` | Species-specific values |
 | Datafiles | Input data dir | Specify species/tracks to submit |
 
-The datafiles source can be replaced/modified with command-line params (`-g`,`-t`).
+- The datafiles source can be replaced/modified with command-line params (`-g`,`-t`)
+- Gene track overrides (`gene-track-desc.csv`) was generated/updated from Metadata API with `utils/get_analysis_descs.py` script. `variation-track-desc.csv` was converted from input JSON (handed over from Variation team).
 
 ### Legacy scripts
-Scripts kept for historical record, safe to be be removed.
+Kept for historical record, safe to delete.
 - import_data.py: legacy data importer script; useful as an example of updating tracks database through Django datamodels 
 - grant_access.sh: useful when read/write database users don't have a shared db schema
 - submit_tracks_241: initial track submission script


### PR DESCRIPTION
### Description
This PR:
- Migrates from dev to main branch (to remove dev branch)
- Updates ci to migrate from dev to main branch
- Brings all beta 3 track data updates to main branch for reloading the tracks database
  - redistribution of track order values ([this commit](https://github.com/Ensembl/ensembl-web-track-api/commit/fb39649948b7827e3070e035670a7af722d31cb6); visible track order not changed)
  - will go together with already merged changes ([this](https://github.com/Ensembl/ensembl-web-track-api/commit/c6b3dcf10d412f9be38aaed81ce0ab3e69ca4e7e) and [this](https://github.com/Ensembl/ensembl-web-track-api/commit/5bf33362e2ad3aadd9261ccfe3e7be142f8d6cb9)) to update tracks DB
- Updates documentation

### Related JIRA Issue(s)
[ENSWBSITES-2840](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2840)

### Review App URL(s) 
Tracks have been reloaded from this branch to dev: http://dev-2020.enseml.org

### Knowledge Base
NA

### Example(s)
Track payloads from Track API should have the metadata values (e.g. labels/descriptions) included in this PR (templates/csv files).

### Related tasks
After this PR is merged:
* Reload tracks to staging/prod (SOP) after tracks look good in dev
* Remove dev branch after the new ci/cd pipeline is confirmed working

### Checklist

- [ ] Black formatting
- [ ] Tests
