### PR TITLE
Update tracks POST endpoint

### DIFF
--- a/templates/regulatory-features.yaml
+++ b/templates/regulatory-features.yaml
@@ -11,7 +11,10 @@ label: Regulatory annotation
 display_order: 300
 on_by_default: true
 description: |-
-  Promoters, enhancers and open chromatin regions are available for all species. 
-  Transcription factor binding and CTCF binding sites are only available for human and mouse.
+  Promoters, enhancers, and open chromatin regions are available for all species.
+  CTCF binding sites are only available for some species.
+sources:
+  - name: Ensembl Regulation
+    url: https://regulation.ensembl.org
 datafiles:
   regulation: regulatory-features.bb

--- a/templates/variant-track-desc.csv
+++ b/templates/variant-track-desc.csv
@@ -4,3 +4,4 @@ bc9cb479-b1e3-460b-b4ac-d20b0fe1b350,CNR-ITB short variants,CNR-ITB,,"All short 
 35a40586-9cb2-4d89-a7db-d00511691d09,The 150 TGRSP short variants,150 Tomato Genome ReSequencing Project,https://www.tomatogenome.wur.nl,All short variants (SNPs and indels) data from the 150 Tomato Genome ReSequencing Project
 a73357ab-93e7-11ec-a39d-005056b38ce3,Short variants (all sources),"CerealsDB, EMS-induced mutation, Inter-homoeologous, Nottingham_WRC, Watkins-exome-capture, Exome_Capture_Diversity",,All short variants (SNPs and indels)
 2284d28a-2cf7-41f0-bed6-0982601f7888,EVA short variants,EVA,https://www.ebi.ac.uk/eva,"All short variants (SNPs and indels) data from European Variation Archive (EVA) - release 3"
+4c07817b-c7c5-463f-8624-982286bc4355,dbSNP,https://www.ncbi.nlm.nih.gov/snp,"All short variants (SNPs and indel) data from dbSNP - build 157"

--- a/tracks/serializers.py
+++ b/tracks/serializers.py
@@ -51,7 +51,7 @@ class WriteTrackSerializer(BaseTrackSerializer):
         category_id = category_data.pop('track_category_id')
         category_obj, created = Category.objects.get_or_create(track_category_id=category_id, defaults=category_data)
         sources = validated_data.pop('sources') if 'sources' in validated_data else []
-        track_obj = Track.objects.get_or_create(
+        track_obj, created = Track.objects.update_or_create(
             category=category_obj,
             genome_id=validated_data["genome_id"],
             label=validated_data["label"],

--- a/tracks/serializers.py
+++ b/tracks/serializers.py
@@ -45,6 +45,7 @@ class WriteTrackSerializer(BaseTrackSerializer):
         extra_kwargs = {
             "genome_id": {"write_only": True}
         }
+        validators = [] # ignore uniqueness constraint
     
     def create(self, validated_data):
         category_data = validated_data.pop('category')

--- a/tracks/serializers.py
+++ b/tracks/serializers.py
@@ -51,7 +51,14 @@ class WriteTrackSerializer(BaseTrackSerializer):
         category_id = category_data.pop('track_category_id')
         category_obj, created = Category.objects.get_or_create(track_category_id=category_id, defaults=category_data)
         sources = validated_data.pop('sources') if 'sources' in validated_data else []
-        track_obj = Track.objects.create(category=category_obj, **validated_data)
+        track_obj = Track.objects.get_or_create(
+            category=category_obj,
+            genome_id=validated_data["genome_id"],
+            label=validated_data["label"],
+            additional_info=validated_data["additional_info"],
+            datafiles=validated_data["datafiles"],
+            defaults=validated_data
+        )
         if(track_obj.trigger[1].startswith("expand")): #hack for expansion tracks
             track_obj.trigger.append(track_obj.track_id)
             track_obj.save()

--- a/tracks/serializers.py
+++ b/tracks/serializers.py
@@ -56,7 +56,7 @@ class WriteTrackSerializer(BaseTrackSerializer):
             category=category_obj,
             genome_id=validated_data["genome_id"],
             label=validated_data["label"],
-            additional_info=validated_data["additional_info"],
+            additional_info=validated_data.get("additional_info",""),
             datafiles=validated_data["datafiles"],
             defaults=validated_data
         )


### PR DESCRIPTION
### Description
* Modify `POST /track` endpoint to update a track record (instead of returning an error) when the submitted track already exists
* Update some track descriptions for beta 6 release

### Related JIRA Issue(s)


### Review App URL(s) 
https://update-tracks.review.ensembl.org

### Example(s)
Update the description of regulation track for human:
`POST https://update-tracks.review.ensembl.org/api/tracks/track`
```json
{
    "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
    "category": {
        "track_category_id": "regulatory-features",
        "label": "Regulation",
        "type": "Regulation"
    },
    "trigger": ["track", "regulation"],
    "type": "regular",
    "label": "Regulatory annotation",
    "display_order": 300,
    "on_by_default": true,
    "description": "My new description",
    "datafiles": {
        "regulation": "regulatory-features.bb"
    }
}
```
Expected behaviour:

- Response `201` (with the existing track ID) instead of `400`
- New description visible for regulation track in the response of `https://update-tracks.review.ensembl.org/api/tracks/track_categories/a7335667-93e7-11ec-a39d-005056b38ce3`

### Checklist

- [ ] Black formatting
- [ ] Tests

### Dependencies 
None. Compatible with the existing track submission script and Ensembl site.